### PR TITLE
Add /functions endpoint

### DIFF
--- a/controllers/functions_controller.rb
+++ b/controllers/functions_controller.rb
@@ -43,9 +43,9 @@ class FunctionsController < ApplicationController
   get '/?' do 
     msg='FunctionsController.get (many)'
     captures=params.delete('captures') if params.key? 'captures'
-    STDERR.puts "#{msg}: params='#{params}'"
+    STDERR.puts "#{msg}: params=#{params}"
     result = FetchVNFDsService.call(symbolized_hash(params))
-    STDERR.puts "#{msg}: result='#{result}'"
+    STDERR.puts "#{msg}: result=#{result}"
     halt 404, {}, {error: "No functions fiting the provided parameters ('#{params}') were found"}.to_json if result.to_s.empty? # covers nil
     halt 200, {}, result.to_json
   end
@@ -53,10 +53,10 @@ class FunctionsController < ApplicationController
   get '/:function_uuid/?' do 
     msg='FunctionsController.get (single)'
     captures=params.delete('captures') if params.key? 'captures'
-    STDERR.puts "#{msg}: params='#{params}'"
-    result = FetchVNFDsService.call(uuid: params[:function_uuid])
+    STDERR.puts "#{msg}: params['function_uuid']='#{params['function_uuid']}'"
+    result = FetchVNFDsService.call(uuid: params['function_uuid'])
     STDERR.puts "#{msg}: result=#{result}"
-    halt 404, {}, {error: ERROR_FUNCTION_NOT_FOUND % params[:function_uuid]}.to_json if result == {}
+    halt 404, {}, {error: ERROR_FUNCTION_NOT_FOUND % params['function_uuid']}.to_json if result == {}
     halt 200, {}, result.to_json
   end
   

--- a/controllers/functions_controller.rb
+++ b/controllers/functions_controller.rb
@@ -41,16 +41,22 @@ class FunctionsController < ApplicationController
   before { content_type :json}
   
   get '/?' do 
+    msg='FunctionsController.get (many)'
     captures=params.delete('captures') if params.key? 'captures'
+    STDERR.puts "#{msg}: params='#{params}'"
     result = FetchVNFDsService.call(symbolized_hash(params))
+    STDERR.puts "#{msg}: result='#{result}'"
     halt 404, {}, {error: "No functions fiting the provided parameters ('#{params}') were found"}.to_json if result.to_s.empty? # covers nil
     halt 200, {}, result.to_json
   end
   
-  get '/:service_uuid/?' do 
+  get '/:function_uuid/?' do 
+    msg='FunctionsController.get (single)'
     captures=params.delete('captures') if params.key? 'captures'
-    result = FetchVNFDsService.call(symbolized_hash(params))
-    halt 404, {}, {error: ERROR_FUNCTION_NOT_FOUND % params[:service_uuid]}.to_json if result.to_s.empty? # covers nil
+    STDERR.puts "#{msg}: params='#{params}'"
+    result = FetchVNFDsService.call(uuid: params[:function_uuid])
+    STDERR.puts "#{msg}: result=#{result}"
+    halt 404, {}, {error: ERROR_FUNCTION_NOT_FOUND % params[:function_uuid]}.to_json if result == {}
     halt 200, {}, result.to_json
   end
   

--- a/controllers/services_controller.rb
+++ b/controllers/services_controller.rb
@@ -42,14 +42,14 @@ class ServicesController < ApplicationController
   
   get '/?' do 
     captures=params.delete('captures') if params.key? 'captures'
-    result = FetchServicesService.call(symbolized_hash(params))
-    halt 404, {}, {error: "No services fiting the provided parameters ('#{params}') were found"}.to_json if result.to_s.empty? # covers nil
+    result = FetchNSDService.call(symbolized_hash(params))
+    halt 404, {}, {error: "No packages fiting the provided parameters ('#{params}') were found"}.to_json if result.to_s.empty? # covers nil
     halt 200, {}, result.to_json
   end
   
   get '/:service_uuid/?' do 
     captures=params.delete('captures') if params.key? 'captures'
-    result = FetchServicesService.call(symbolized_hash(params))
+    result = FetchNSDService.call(symbolized_hash(params))
     halt 404, {}, {error: ERROR_SERVICE_NOT_FOUND % params[:service_uuid]}.to_json if result.to_s.empty? # covers nil
     halt 200, {}, result.to_json
   end

--- a/services/fetch_nsd_service.rb
+++ b/services/fetch_nsd_service.rb
@@ -43,7 +43,7 @@ class FetchNSDService < FetchService
     STDERR.puts "%s - %s: %s" % [Time.now.utc.to_s, 'FetchNSDService', NO_CATALOGUE_URL_DEFINED_ERROR]
     raise ArgumentError.new(NO_CATALOGUE_URL_DEFINED_ERROR) 
   end
-  site CATALOGUE_URL+'/network-services'
+  self.site=CATALOGUE_URL+'/network-services'
 end
 
 

--- a/services/fetch_service.rb
+++ b/services/fetch_service.rb
@@ -70,9 +70,10 @@ class FetchService
       case response
       when Net::HTTPSuccess
         body = response.read_body
-        STDERR.puts "#{msg}: body=#{body}"
+        STDERR.puts "#{msg}: 200 (Ok) body=#{body}"
         return JSON.parse(body, quirks_mode: true, symbolize_names: true)
       when Net::HTTPNotFound
+        STDERR.puts "#{msg}: 404 Not found) body=#{body}"
         return {} # ArgumentError.new("Entity chosen with params #{original_params} was not found")
       else
         return nil # ArgumentError.new("#{response.message}")

--- a/services/fetch_service.rb
+++ b/services/fetch_service.rb
@@ -36,20 +36,30 @@ require 'json'
 
 class FetchService  
   ERROR_NS_UUID_IS_MANDATORY='Network Service UUID parameter is mandatory'
-  
-  def self.site(url) @@site = url end 
+
+  class << self
+    attr_accessor :site
+  end
+
+  def site=(value)
+    self.class.site = value
+  end
+
+  def site
+    self.class.site
+  end
   
   def self.call(params)
     msg=self.name+'#'+__method__.to_s
-    STDERR.puts "#{msg}: params=#{params}"
+    STDERR.puts "#{msg}: params=#{params} site=#{self.site}"
     original_params = params.dup
     begin
       if params.key?(:uuid)
         uuid = params.delete :uuid
-        uri = URI.parse(@@site+'/'+uuid)
+        uri = URI.parse(self.site+'/'+uuid)
         # mind that there cany be more params, so we might need to pass params as well
       else
-        uri = URI.parse(@@site)
+        uri = URI.parse(self.site)
         uri.query = URI.encode_www_form(sanitize(params))
       end
       STDERR.puts "#{msg}: uri=#{uri}"
@@ -71,29 +81,6 @@ class FetchService
       STDERR.puts "%s - %s: %s" % [Time.now.utc.to_s, msg, e.message]
     end
     nil
-=begin
-    msg=self.name+'#'+__method__.to_s
-    STDERR.puts "#{msg}: params=#{params}"
-    begin
-      if params.key?(:uuid)
-        service_uuid = params.delete :service_uuid
-        uri = URI.parse(CATALOGUE_URL+'/network-services/'+service_uuid)
-        # mind that there ccany be more params, so we might need to pass params as well
-      else
-        uri = URI.parse(CATALOGUE_URL+'/network-services')
-        uri.query = URI.encode_www_form(sanitize(params))
-      end
-      STDERR.puts "#{msg}: querying uri=#{uri}"
-      request = Net::HTTP::Get.new(uri)
-      request['content-type'] = 'application/json'
-      response = Net::HTTP.start(uri.hostname, uri.port) {|http| http.request(request)}
-      STDERR.puts "#{msg}: querying response=#{response}"
-      return JSON.parse(response.read_body, quirks_mode: true, symbolize_names: true) if response.is_a?(Net::HTTPSuccess)
-    rescue Exception => e
-      STDERR.puts "%s - %s: %s" % [Time.now.utc.to_s, msg, e.message]
-    end
-    nil
-=end    
   end
   
   private
@@ -104,4 +91,30 @@ class FetchService
   end
 end
 
+=begin
+class A
+  class << self
+    attr_accessor :class_var
+  end
 
+  def set_class_var(value)
+    self.class.class_var = value
+  end
+
+  def get_class_var
+    self.class.class_var
+  end
+end
+
+class B < A; end
+
+A.class_var = 'a'
+B.class_var = 'b'
+puts A.class_var # => a
+puts B.class_var # => b
+
+A.new.set_class_var 'aa'
+B.new.set_class_var 'bb'
+puts A.new.get_class_var # => aa
+puts B.new.get_class_var # => bb
+=end

--- a/spec/apis/functions_api_spec.rb
+++ b/spec/apis/functions_api_spec.rb
@@ -33,50 +33,39 @@
 # encoding: utf-8
 require_relative '../spec_helper'
 
-RSpec.describe FunctionsController, type: :controller do
-  def app() described_class end
+RSpec.describe 'Functions API', type: :api do
+  def app() FunctionsController end
   let(:site)  {FetchVNFDsService.site}
   let(:uuid_1) {SecureRandom.uuid}
   let(:function_1_metadata) {{uuid: uuid_1, vnfd: {vendor: '5gtango', name: 'whatever', version: '0.0.1'}}}
   let(:uuid_2) {SecureRandom.uuid}
-  let(:headers) do
-    uri = URI(site)
-    {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Type'=>'application/json', 
-      'Host'=>"#{uri.host}:#{uri.port}", 'User-Agent'=>'Ruby'}
-  end
 
   context 'with UUID given' do
+    #describe "API authentication" , :type => :api do
+    #  let!(:user) { FactoryGirl.create(:user) }
+    #  it "making a request without cookie token " do
+    #    get "/api/v1/items/1",:formate =>:json
+    #    last_response.status.should eql(401)
+    #    error = {:error=>'You need to sign in or sign up before continuing.'}
+    #    last_response.body.should  eql(error.to_json)
+    #  end
+    #end
+=begin
     it 'returns the existing function' do
-      stub_request(:get, site+'/'+uuid_1).with(headers: headers).to_return(status: 200, body: function_1_metadata.to_json, headers: headers)
+      stub_request(:get, site+'/'+uuid_1).to_return(status: 200, body: function_1_metadata.to_json, headers: {})
       get '/'+uuid_1
-      expect(last_response).to be_ok
-      expect(last_response.body).to eq(function_1_metadata.to_json)
+      STDERR.puts "response=#{response.inspect}"
+      expect(response).to have_http_status(:success)
+      #expect(response).to be_success
+      #json = JSON.parse(response.body)
+      expect(response.body).to include(function_1_metadata.to_json)
     end
     it 'rejects non-existing function' do
-      stub_request(:get, site+'/'+uuid_2).with(headers: headers).to_return(status: 404, body: '', headers: headers)
+      stub_request(:get, site+'/'+uuid_2).to_return(status: 404, body: '', headers: {})
       get '/'+uuid_2
-      STDERR.puts "last_response=#{last_response.inspect}"
-      expect(last_response).to be_not_found
+      STDERR.puts "response=#{response.inspect}"
+      expect(esponse).to eq(404)
     end
-  end
-=begin
-  context 'without UUID given' do
-    let(:function_2_metadata) {{uuid: uuid_2, vnfd: {vendor: '5gtango', name: 'whatever', version: '0.0.1'}}}
-    let(:functions) {[ function_1_metadata, function_2_metadata]}
-    it 'adding default parameters for page size and number' do
-      stub_request(:get, site+'?page_number='+default_page_number+'&page_size='+default_page_size).
-        with(headers: headers).to_return(status: 200, body: services_metadata.to_json, headers: headers)
-      get '/'
-      expect(last_response).to be_ok
-      expect(last_response.body).to eq(functions.to_json)
-    end
-
-    it 'returning Ok (200) and an empty array when no service is found' do
-      allow(FetchVNFDsService).to receive(:call).with({}).and_return([])
-      get '/'
-      expect(last_response).to be_ok
-      expect(last_response.body).to eq([].to_json)
-    end
-  end
 =end
+  end
 end

--- a/spec/controllers/functions_controller_spec.rb
+++ b/spec/controllers/functions_controller_spec.rb
@@ -41,14 +41,15 @@ RSpec.describe FunctionsController, type: :controller do
 
   context 'with UUID given' do
     it 'returns the existing function' do
-      allow(FetchVNFDsService).to receive(:call).with(uudi: uuid_1).and_return(function_1_metadata)
+      allow(FetchVNFDsService).to receive(:call).with(uuid: uuid_1).and_return(function_1_metadata)
       get '/'+uuid_1
       expect(last_response).to be_ok
-      expect(last_response.body).to eq(request_1.to_json)
+      expect(last_response.body).to eq(function_1_metadata.to_json)
     end
     it 'rejects non-existing function' do
-      allow(FetchVNFDsService).to receive(:call).with(uudi: uuid_2).and_return({})
+      allow(FetchVNFDsService).to receive(:call).with(uuid: uuid_2).and_return({})
       get '/'+uuid_2
+      STDERR.puts "last_response=#{last_response.inspect}"
       expect(last_response).to be_not_found
     end
   end

--- a/spec/requests/functions_requests_spec.rb
+++ b/spec/requests/functions_requests_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe FunctionsController, type: :controller do
   let(:headers) do
     uri = URI(site)
     {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Type'=>'application/json', 
-      'Host'=>"#{uri.host}", 'User-Agent'=>'Ruby'} #:#{uri.port}
+      'Host'=>"#{uri.host}:#{uri.port}", 'User-Agent'=>'Ruby'}
   end
 
   context 'with UUID given' do

--- a/spec/requests/functions_requests_spec.rb
+++ b/spec/requests/functions_requests_spec.rb
@@ -1,0 +1,82 @@
+## Copyright (c) 2015 SONATA-NFV, 2017 5GTANGO [, ANY ADDITIONAL AFFILIATION]
+## ALL RIGHTS RESERVED.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+## Neither the name of the SONATA-NFV, 5GTANGO [, ANY ADDITIONAL AFFILIATION]
+## nor the names of its contributors may be used to endorse or promote
+## products derived from this software without specific prior written
+## permission.
+##
+## This work has been performed in the framework of the SONATA project,
+## funded by the European Commission under Grant number 671517 through
+## the Horizon 2020 and 5G-PPP programmes. The authors would like to
+## acknowledge the contributions of their colleagues of the SONATA
+## partner consortium (www.sonata-nfv.eu).
+##
+## This work has been performed in the framework of the 5GTANGO project,
+## funded by the European Commission under Grant number 761493 through
+## the Horizon 2020 and 5G-PPP programmes. The authors would like to
+## acknowledge the contributions of their colleagues of the 5GTANGO
+## partner consortium (www.5gtango.eu).
+# frozen_string_literal: true
+# encoding: utf-8
+require_relative '../spec_helper'
+
+RSpec.describe FunctionsController, type: :controller do
+  def app() described_class end
+  let(:site)  {FetchVNFDsService.site}
+  let(:uuid_1) {SecureRandom.uuid}
+  let(:function_1_metadata) {{uuid: uuid_1, vnfd: {vendor: '5gtango', name: 'whatever', version: '0.0.1'}}}
+  let(:uuid_2) {SecureRandom.uuid}
+  let(:headers) do
+    uri = URI(site)
+    {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Type'=>'application/json', 
+      'Host'=>"#{uri.host}", 'User-Agent'=>'Ruby'} #:#{uri.port}
+  end
+
+  context 'with UUID given' do
+    it 'returns the existing function' do
+      stub_request(:get, site+'/'+uuid_1).with(headers: headers).to_return(status: 200, body: function_1_metadata.to_json, headers: headers)
+      get '/'+uuid_1
+      expect(last_response).to be_ok
+      expect(last_response.body).to eq(function_1_metadata.to_json)
+    end
+    it 'rejects non-existing function' do
+      stub_request(:get, site+'/'+uuid_2).with(headers: headers).to_return(status: 404, body: '', headers: headers)
+      get '/'+uuid_2
+      STDERR.puts "last_response=#{last_response.inspect}"
+      expect(last_response).to be_not_found
+    end
+  end
+=begin
+  context 'without UUID given' do
+    let(:function_2_metadata) {{uuid: uuid_2, vnfd: {vendor: '5gtango', name: 'whatever', version: '0.0.1'}}}
+    let(:functions) {[ function_1_metadata, function_2_metadata]}
+    it 'adding default parameters for page size and number' do
+      stub_request(:get, site+'?page_number='+default_page_number+'&page_size='+default_page_size).
+        with(headers: headers).to_return(status: 200, body: services_metadata.to_json, headers: headers)
+      get '/'
+      expect(last_response).to be_ok
+      expect(last_response.body).to eq(functions.to_json)
+    end
+
+    it 'returning Ok (200) and an empty array when no service is found' do
+      allow(FetchVNFDsService).to receive(:call).with({}).and_return([])
+      get '/'
+      expect(last_response).to be_ok
+      expect(last_response.body).to eq([].to_json)
+    end
+  end
+=end
+end

--- a/spec/services/fetch_nsd_service_spec.rb
+++ b/spec/services/fetch_nsd_service_spec.rb
@@ -47,15 +47,15 @@ RSpec.describe FetchNSDService do
     end
     context 'with UUID' do
       it 'returns the requested service meta-data when it exists' do
-        stub_request(:get, site+'/'+uuid_1).with(headers: headers).to_return(status: 200, body: service_1_metadata.to_json, headers: {})
+        stub_request(:get, site+'/'+uuid_1).to_return(status: 200, body: service_1_metadata.to_json, headers: {}) # .with(headers: headers)
         expect(described_class.call(uuid: uuid_1)).to eq(service_1_metadata)
       end
       it 'returns {} when the requested service does not exist' do
-        stub_request(:get, site+'/'+uuid_1).with(headers: headers).to_return(status: 404, body: '{}', headers: {})
+        stub_request(:get, site+'/'+uuid_1).to_return(status: 404, body: '{}', headers: {}) #.with(headers: headers)
         expect(described_class.call(uuid: uuid_1)).to be_empty
       end
       it 'returns nil when other errors occur' do
-        stub_request(:get, site+'/'+uuid_1).with(headers: headers).to_return(status: 500, body: '', headers: {})
+        stub_request(:get, site+'/'+uuid_1).to_return(status: 500, body: '', headers: {}) #.with(headers: headers)
         expect(described_class.call(uuid: uuid_1)).to be_nil
       end
     end
@@ -67,36 +67,35 @@ RSpec.describe FetchNSDService do
       let(:default_page_number) {ENV.fetch('DEFAULT_PAGE_NUMBER', '0')}
       it 'returns the requested services meta-data when no restriction is passed' do
         stub_request(:get, site+'?page_number='+default_page_number+'&page_size='+default_page_size).
-          with(headers: headers).to_return(status: 200, body: services_metadata.to_json, headers: {})
+          to_return(status: 200, body: services_metadata.to_json, headers: {}) #with(headers: headers).
         expect(described_class.call({})).to eq(services_metadata)
       end
       it 'calls the Catalogue with default params' do      
         stub_request(:get, site+'?page_number='+default_page_number+'&page_size='+default_page_size).
-          with(headers: headers).to_return(status: 200, body: services_metadata.to_json, headers: {})
+          to_return(status: 200, body: services_metadata.to_json, headers: {}) # with(headers: headers).
         expect(described_class.call({})).to eq(services_metadata)
       end
       it 'calls the Catalogue with default page_size when only page_number is passed' do      
         stub_request(:get, site+'?page_number=1&page_size='+default_page_size).
-          with(headers: headers).to_return(status: 200, body: [].to_json, headers: headers)
+          to_return(status: 200, body: [].to_json, headers: headers) # with(headers: headers).
         expect(described_class.call({page_number: 1})).to eq([])
       end
       it 'calls the Catalogue with default page_number when only page_size is passed' do      
         stub_request(:get, site+'?page_number='+default_page_number+'&page_size=1').
-          with(headers: headers).to_return(status: 200, body: [service_1_metadata].to_json, headers: {})
+          to_return(status: 200, body: [service_1_metadata].to_json, headers: {}) #with(headers: headers).
         expect(described_class.call({page_size: 1})).to eq([service_1_metadata])
       end
       it 'calls the Catalogue with default page_number and page_size, returning existing services' do      
         stub_request(:get, site+'?page_number='+default_page_number+'&page_size='+default_page_size).
-          with(headers: headers).
-          to_return(status: 200, body: services_metadata.to_json, headers: {'content-type' => 'application/json'})
+          to_return(status: 200, body: services_metadata.to_json, headers: {'content-type' => 'application/json'}) #with(headers: headers).
         expect(described_class.call({page_size: default_page_size, page_number: default_page_number})).to eq(services_metadata)
       end
       it 'returns [] when the requested services do not exist' do
-        stub_request(:get, site+'/').with(headers: headers).to_return(status: 404, body: '[]', headers: {})
+        stub_request(:get, site+'/').to_return(status: 404, body: '[]', headers: {}) # .with(headers: headers)
         expect(described_class.call(uuid: uuid_1)).to eq(nil)
       end
       it 'returns nil when other errors occur' do
-        stub_request(:get, site+'/').with(headers: headers).to_return(status: 500, body: '', headers: {})
+        stub_request(:get, site+'/').to_return(status: 500, body: '', headers: {}) # .with(headers: headers)
         expect(described_class.call(uuid: uuid_1)).to be_nil
       end
     end

--- a/spec/services/fetch_nsd_service_spec.rb
+++ b/spec/services/fetch_nsd_service_spec.rb
@@ -36,12 +36,14 @@ require 'uri'
 
 RSpec.describe FetchNSDService do
   describe '.call' do
-    let(:site)  {FetchNSDService.class_variable_get(:@@site)}
+    let(:site)  {described_class.site}
     let(:uuid_1) {SecureRandom.uuid}
     let(:service_1_metadata) {{uuid: uuid_1, nsd: {vendor: '5gtango', name: 'whatever', version: '0.0.1'}}}
     let(:headers) do
       uri = URI(site)
-      {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Type'=>'application/json', 'Host'=>"#{uri.host}:#{uri.port}", 'User-Agent'=>'Ruby'}
+      STDERR.puts "site=#{site}, uri=#{uri}"
+      {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Type'=>'application/json', 
+        'Host'=>"#{uri.host}:#{uri.port}", 'User-Agent'=>'Ruby'}
     end
     context 'with UUID' do
       it 'returns the requested service meta-data when it exists' do
@@ -52,7 +54,7 @@ RSpec.describe FetchNSDService do
         stub_request(:get, site+'/'+uuid_1).with(headers: headers).to_return(status: 404, body: '{}', headers: {})
         expect(described_class.call(uuid: uuid_1)).to be_empty
       end
-      it 'returns nil when tother errors occur' do
+      it 'returns nil when other errors occur' do
         stub_request(:get, site+'/'+uuid_1).with(headers: headers).to_return(status: 500, body: '', headers: {})
         expect(described_class.call(uuid: uuid_1)).to be_nil
       end
@@ -65,12 +67,12 @@ RSpec.describe FetchNSDService do
       let(:default_page_number) {ENV.fetch('DEFAULT_PAGE_NUMBER', '0')}
       it 'returns the requested services meta-data when no restriction is passed' do
         stub_request(:get, site+'?page_number='+default_page_number+'&page_size='+default_page_size).
-          with(headers: headers).to_return(status: 200, body: services_metadata.to_json, headers: headers)
+          with(headers: headers).to_return(status: 200, body: services_metadata.to_json, headers: {})
         expect(described_class.call({})).to eq(services_metadata)
       end
       it 'calls the Catalogue with default params' do      
         stub_request(:get, site+'?page_number='+default_page_number+'&page_size='+default_page_size).
-          with(headers: headers).to_return(status: 200, body: services_metadata.to_json, headers: headers)
+          with(headers: headers).to_return(status: 200, body: services_metadata.to_json, headers: {})
         expect(described_class.call({})).to eq(services_metadata)
       end
       it 'calls the Catalogue with default page_size when only page_number is passed' do      
@@ -80,7 +82,7 @@ RSpec.describe FetchNSDService do
       end
       it 'calls the Catalogue with default page_number when only page_size is passed' do      
         stub_request(:get, site+'?page_number='+default_page_number+'&page_size=1').
-          with(headers: headers).to_return(status: 200, body: [service_1_metadata].to_json, headers: headers)
+          with(headers: headers).to_return(status: 200, body: [service_1_metadata].to_json, headers: {})
         expect(described_class.call({page_size: 1})).to eq([service_1_metadata])
       end
       it 'calls the Catalogue with default page_number and page_size, returning existing services' do      
@@ -93,7 +95,7 @@ RSpec.describe FetchNSDService do
         stub_request(:get, site+'/').with(headers: headers).to_return(status: 404, body: '[]', headers: {})
         expect(described_class.call(uuid: uuid_1)).to eq(nil)
       end
-      it 'returns nil when tother errors occur' do
+      it 'returns nil when other errors occur' do
         stub_request(:get, site+'/').with(headers: headers).to_return(status: 500, body: '', headers: {})
         expect(described_class.call(uuid: uuid_1)).to be_nil
       end

--- a/spec/services/fetch_vnfd_service_spec.rb
+++ b/spec/services/fetch_vnfd_service_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe FetchVNFDsService do
   describe '.call' do
     let(:site)  {described_class.site}
     let(:uuid_1) {SecureRandom.uuid}
+    let(:uuid_2) {SecureRandom.uuid}
     let(:function_1_metadata) {{uuid: uuid_1, vnfd: {vendor: '5gtango', name: 'whatever', version: '0.0.1'}}}
     let(:headers) do
       uri = URI(site)
@@ -46,13 +47,15 @@ RSpec.describe FetchVNFDsService do
     end
     context 'with UUID' do
       it 'returns the requested function meta-data' do
-        stub_request(:get, site+'/'+uuid_1).
-          with(headers: headers).to_return(status: 200, body: function_1_metadata.to_json, headers: headers)
+        stub_request(:get, site+'/'+uuid_1).to_return(status: 200, body: function_1_metadata.to_json, headers: {})
         expect(described_class.call(uuid: uuid_1)).to eq(function_1_metadata)
+      end
+      it 'returns {} when the requested function does not exist' do
+        stub_request(:get, site+'/'+uuid_2).to_return(status: 404, body: '', headers: {})
+        expect(described_class.call(uuid: uuid_2)).to eq({})
       end
     end
     context 'without UUID' do
-      let(:uuid_2) {SecureRandom.uuid}
       let(:function_2_metadata) {{uuid: uuid_2, vnfd: {vendor: '5gtango', name: 'whatever', version: '0.0.2'}}}
       let(:functions_metadata) {[function_1_metadata, function_2_metadata]}
       let(:headers) {{'content-type' => 'application/json'}}


### PR DESCRIPTION
This endpoint is added here (and `/services` will have to migrate from `tng-gtk-common` to here as well, and then adjusted and replicated to `tng-gtk-vnv`) since we have discovered that `/functions` have peculiarities that make them unique to SP/VnV