### PR TITLE
Fix content type on the call to the Slice Manager

### DIFF
--- a/services/process_create_slice_instance_request.rb
+++ b/services/process_create_slice_instance_request.rb
@@ -173,7 +173,7 @@ class ProcessCreateSliceInstanceRequest < ProcessRequestBase
 
     # Create the HTTP objects
     http = Net::HTTP.new(uri.host, uri.port)
-    request = Net::HTTP::Post.new(uri, {'Content-Type': 'text/json'})    
+    request = Net::HTTP::Post.new(uri, {'Content-Type': 'application/json'})    
     request.body = params.to_json
 
     # Send the request


### PR DESCRIPTION
This was (I think) erroneously set to `text\json`.